### PR TITLE
Added s_dev option and hiding to the dmaHD_ settings

### DIFF
--- a/menu/ui/controls.menu
+++ b/menu/ui/controls.menu
@@ -535,7 +535,7 @@
 			name shoot
 			group grpControls
 			type ITEM_TYPE_MULTI
-			text "Autopickup Guns:"
+			text "Autopickup Guns/Items:"
 			cvar "cg_autopickup"
 			cvarFloatList { "No" 0 "Yes" -1 }
 			rect 99 140 256 20

--- a/menu/ui/controls.menu
+++ b/menu/ui/controls.menu
@@ -513,6 +513,41 @@
 			mouseenter { show keyBindStatus }
 			mouseexit { hide keyBindStatus }
 		}
+		
+		itemDef {
+			name shoot
+			group grpControls
+			type ITEM_TYPE_BIND
+			text "interact/pickup:"
+			cvar "+button7"
+			rect 99 140 256 20
+			textalign ITEM_ALIGN_RIGHT
+			textalignx 40
+			textaligny 20
+			textscale .25
+			forecolor 1 1 1 1
+			visible 0
+			mouseenter { show keyBindStatus }
+			mouseexit { hide keyBindStatus }
+		}
+		
+		itemDef {
+			name shoot
+			group grpControls
+			type ITEM_TYPE_MULTI
+			text "Autopickup Guns:"
+			cvar "cg_autopickup"
+			cvarFloatList { "No" 0 "Yes" -1 }
+			rect 99 140 256 20
+			textalign ITEM_ALIGN_RIGHT
+			textalignx 40
+			textaligny 20
+			textscale .25
+			forecolor 1 1 1 1
+			visible 0
+			mouseenter { show keyBindStatus }
+			mouseexit { hide keyBindStatus }
+		}
 
 
 
@@ -587,7 +622,7 @@
 			name misc
 			group grpControls
 			type ITEM_TYPE_BIND
-			text "(def)use / doors:"
+			text "interact/pickup:"
 			cvar "+button7"
 			rect 99 60 256 20
 			textalign ITEM_ALIGN_RIGHT

--- a/menu/ui/ingame_controls.menu
+++ b/menu/ui/ingame_controls.menu
@@ -527,7 +527,7 @@
 			text "Autopickup Guns/Items:"
 			cvar "cg_autopickup"
 			cvarFloatList { "No" 0 "Yes" -1 }
-			0 180 320 15
+			rect 0 180 320 15
 			textalign ITEM_ALIGN_RIGHT
 			textalignx 40
 			textaligny 20

--- a/menu/ui/ingame_controls.menu
+++ b/menu/ui/ingame_controls.menu
@@ -502,6 +502,41 @@
 			mouseenter { show keyBindStatus }
 			mouseexit { hide keyBindStatus }
 		}
+		itemDef {
++			name shoot
++			group grpControls
++			type ITEM_TYPE_BIND
++			text "interact/pickup:"
++			cvar "+button7"
++			rect 0 165 320 15
++			textalign ITEM_ALIGN_RIGHT
++			textalignx 40
++			textaligny 20
++			textscale .25
++			forecolor 1 1 1 1
++			visible 0
++			mouseenter { show keyBindStatus }
++			mouseexit { hide keyBindStatus }
++		}
++		
++		itemDef {
++			name shoot
++			group grpControls
++			type ITEM_TYPE_MULTI
++			text "Autopickup Guns/Items:"
++			cvar "cg_autopickup"
++			cvarFloatList { "No" 0 "Yes" -1 }
++			0 180 320 15
++			textalign ITEM_ALIGN_RIGHT
++			textalignx 40
++			textaligny 20
++			textscale .25
++			forecolor 1 1 1 1
++			visible 0
++			mouseenter { show keyBindStatus }
++			mouseexit { hide keyBindStatus }
++		}
+		
 
 		itemDef {
 			name ctr_miscellaneous
@@ -576,7 +611,7 @@
 			name misc
 			group grpControls
 			type ITEM_TYPE_BIND
-			text "(def)use / doors:"
+			text "interact/pickup"
 			cvar "+button7"
 			rect 0 105 320 15
 			textalign ITEM_ALIGN_RIGHT

--- a/menu/ui/ingame_controls.menu
+++ b/menu/ui/ingame_controls.menu
@@ -503,41 +503,41 @@
 			mouseexit { hide keyBindStatus }
 		}
 		itemDef {
-+			name shoot
-+			group grpControls
-+			type ITEM_TYPE_BIND
-+			text "interact/pickup:"
-+			cvar "+button7"
-+			rect 0 165 320 15
-+			textalign ITEM_ALIGN_RIGHT
-+			textalignx 40
-+			textaligny 20
-+			textscale .25
-+			forecolor 1 1 1 1
-+			visible 0
-+			mouseenter { show keyBindStatus }
-+			mouseexit { hide keyBindStatus }
-+		}
-+		
-+		itemDef {
-+			name shoot
-+			group grpControls
-+			type ITEM_TYPE_MULTI
-+			text "Autopickup Guns/Items:"
-+			cvar "cg_autopickup"
-+			cvarFloatList { "No" 0 "Yes" -1 }
-+			0 180 320 15
-+			textalign ITEM_ALIGN_RIGHT
-+			textalignx 40
-+			textaligny 20
-+			textscale .25
-+			forecolor 1 1 1 1
-+			visible 0
-+			mouseenter { show keyBindStatus }
-+			mouseexit { hide keyBindStatus }
-+		}
+			name shoot
+			group grpControls
+			type ITEM_TYPE_BIND
+			text "interact/pickup:"
+			cvar "+button7"
+			rect 0 165 320 15
+			textalign ITEM_ALIGN_RIGHT
+			textalignx 187
+			maxPaintChars 20
+			textaligny 12
+			textscale .22
+			forecolor 1 1 1 1
+			visible 0
+			mouseenter { show keyBindStatus }
+			mouseexit { hide keyBindStatus }
+		}
 		
-
+		itemDef {
+			name shoot
+			group grpControls
+			type ITEM_TYPE_MULTI
+			text "Autopickup Guns/Items:"
+			cvar "cg_autopickup"
+			cvarFloatList { "No" 0 "Yes" -1 }
+			0 180 320 15
+			textalign ITEM_ALIGN_RIGHT
+			textalignx 40
+			textaligny 20
+			textscale .25
+			forecolor 1 1 1 1
+			visible 0
+			mouseenter { show keyBindStatus }
+			mouseexit { hide keyBindStatus }
+		}
+		
 		itemDef {
 			name ctr_miscellaneous
 			type 1

--- a/menu/ui/ingame_system.menu
+++ b/menu/ui/ingame_system.menu
@@ -621,6 +621,8 @@
 		itemDef {
 			name sound
 			group grpSystem
+			cvartest "dmaHD_enable"
+			hideCvar { "0" }
 			type ITEM_TYPE_MULTI
 			text "Interpolation Quality:"
 			cvar "dmaHD_interpolation"
@@ -638,6 +640,8 @@
 		itemDef {
 			name sound
 			group grpSystem
+			cvartest "dmaHD_enable"
+			hideCvar { "0" }
 			type ITEM_TYPE_MULTI
 			text "Mixer Type:"
 			cvar "dmaHD_mixer"
@@ -651,6 +655,24 @@
 			visible 0
 			action { play "sound/misc/kcaction.wav" }
 		}
+		
+		itemDef {
+			name sound
+			cvartest "dmaHD_enable"
+			hideCvar { "0" }
+			group grpSystem
+			type ITEM_TYPE_EDITFIELD
+			text "Device:"
+			cvar "s_dev"
+			rect 30 220 259 20
+			textalign ITEM_ALIGN_RIGHT
+			textalignx 40
+			textaligny 20
+			textscale .25      
+			forecolor 1 1 1 1
+			visible 1
+		}
+	
 
 		itemDef {
 			name sound

--- a/menu/ui/system.menu
+++ b/menu/ui/system.menu
@@ -699,6 +699,8 @@
 			itemDef {
 				name sound
 				group grpSystem
+				cvartest "dmaHD_enable"
+				hideCvar { "0" }
 				type ITEM_TYPE_MULTI
 				text "Interpolation Quality:"
 				cvar "dmaHD_interpolation"
@@ -716,6 +718,8 @@
 			itemDef {
 				name sound
 				group grpSystem
+				cvartest "dmaHD_enable"
+				hideCvar { "0" }
 				type ITEM_TYPE_MULTI
 				text "Mixer Type:"
 				cvar "dmaHD_mixer"
@@ -730,6 +734,38 @@
 				action { play "sound/misc/kcaction.wav" }
 			}
 
+			itemDef {
+				name sound
+				cvartest "dmaHD_enable"
+				hideCvar { "0" }
+				group grpSystem
+				type ITEM_TYPE_EDITFIELD
+				text "Device:"
+				cvar "s_dev"
+				rect 150 160 200 20
+				textalign ITEM_ALIGN_RIGHT
+				textalignx 40
+				textaligny 20
+				textscale .25      
+				forecolor 1 1 1 1
+				visible 1
+			}
+			itemDef {
+				name sound
+				cvartest "dmaHD_enable"
+				hideCvar { "0" }
+				rect 150 175 300 20
+				textscale 0.12
+				textalign 0
+				textalignx 0
+				textaligny 19
+				forecolor 1 1 1 1
+				autowrapped
+				text "Set this to a sub-string of the output device"
+				visible 1
+				decoration
+			}
+			
 			itemDef {
 				name sound
 				rect 60 180 300 20


### PR DESCRIPTION
Added dmaHD's s_dev feature to both systems/sound and ingame_system/sound menu to select a sound output device via a substring. also added an info for that to the main menu, left it out for the ingame menu, due to the window's size.

Also added hiding to dmaHD exclusive settings, if dmaHD is disabled.