### PR TITLE
Added cg_autopickup to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center"><a href="http://www.urbanterror.info" title="Urban Terror official website" target="_blank"><img src="https://raw.githubusercontent.com/FrozenSand/UrbanTerror42/master/github_frozensand.jpg" alt="Urban Terror 4.2" title="Urban Terror 4.2" /></a></p>
 
-Urban Terror 4.x
+Urban Terror 4.2
 ================
 
-This is the official repository gathering issues about the game Urban Terror and specifically its version 4.x.
+This is the official repository gathering issues about the game Urban Terror and specifically its version 4.2.
 
 If you encounter a bug while using the official **UrTUpdater**, please report it [here](https://github.com/Barbatos/UrTUpdater) instead.
 
@@ -17,7 +17,7 @@ Rules
 Please follow these basic rules in order to keep this place nice:
 
 - Do not insult, troll or harass anyone
-- Do a [small research](https://github.com/FrozenSand/UrbanTerror4/issues?q=is%3Aissue+) before posting a new issue to avoid duplication
+- Do a [small research](https://github.com/FrozenSand/UrbanTerror42/issues?q=is%3Aissue+) before posting a new issue to avoid duplication
 - Do not "UP" the issues yourself, it won't make us process them faster
 - Do not use ALL CAPS - we are not blind (yet)
 
@@ -25,7 +25,7 @@ Please follow these basic rules in order to keep this place nice:
 Reporting Issues
 ----------------
 
-If you encounter a bug while using Urban Terror 4.x, please first check that [a similar issue hasn't been opened yet](https://github.com/FrozenSand/UrbanTerror4/issues).
+If you encounter a bug while using Urban Terror 4.2, please first check that [a similar issue hasn't been opened yet](https://github.com/FrozenSand/UrbanTerror42/issues).
 
 If your bug has not been reported, please provide us at least the following information:
 
@@ -41,8 +41,8 @@ Please place huge logs using tools like [Pastebin](http://pastebin.com) or [Gist
 Feature Requests
 ----------------
 
-While we always appreciate new feature requests, please note that we are heavily working on Urban Terror HD and we are probably not going to implement *huge* changes to Urban Terror 4.x anymore.
-Nevertheless, a section of our forums is dedicated to suggestions, feel free to post [there](http://www.urbanterror.info/forums/forum/57-4x-suggestions/).
+While we always appreciate new feature requests, please note that we are heavily working on Urban Terror HD and we are probably not going to implement *huge* changes to Urban Terror 4.2 anymore.
+Nevertheless, a section of our forums is dedicated to suggestions, feel free to post [there](http://www.urbanterror.info/forums/forum/57-42-suggestions/).
 
 
 **Thanks for your help!**

--- a/menu/ui/controls.menu
+++ b/menu/ui/controls.menu
@@ -513,6 +513,41 @@
 			mouseenter { show keyBindStatus }
 			mouseexit { hide keyBindStatus }
 		}
+		
+		itemDef {
+			name shoot
+			group grpControls
+			type ITEM_TYPE_MULTI
+			text "Autopickup:"
+			cvar "cg_autopickup"
+			cvarFloatList { "No" 0 "Yes" -1 }
+			rect 99 135 256 20
+			textalign ITEM_ALIGN_RIGHT
+			textalignx 40
+			textaligny 20
+			textscale .25
+			forecolor 1 1 1 1
+			visible 0
+			mouseenter { show keyBindStatus }
+			mouseexit { hide keyBindStatus }
+		}
+		
+		itemDef {
+			name shoot
+			group grpControls
+			type ITEM_TYPE_BIND
+			text "interact/pickup:"
+			cvar "+button7"
+			rect 99 150 256 20
+			textalign ITEM_ALIGN_RIGHT
+			textalignx 40
+			textaligny 20
+			textscale .25
+			forecolor 1 1 1 1
+			visible 0
+			mouseenter { show keyBindStatus }
+			mouseexit { hide keyBindStatus }
+		}
 
 
 
@@ -587,7 +622,7 @@
 			name misc
 			group grpControls
 			type ITEM_TYPE_BIND
-			text "(def)use / doors:"
+			text "interact/pickup:"
 			cvar "+button7"
 			rect 99 60 256 20
 			textalign ITEM_ALIGN_RIGHT

--- a/menu/ui/controls.menu
+++ b/menu/ui/controls.menu
@@ -535,6 +535,8 @@
 		itemDef {
 			name shoot
 			group grpControls
+			cvartest cg_autopickup
+			hidecvar { "-1" }
 			type ITEM_TYPE_BIND
 			text "interact/pickup:"
 			cvar "+button7"

--- a/menu/ui/ingame_controls.menu
+++ b/menu/ui/ingame_controls.menu
@@ -508,7 +508,7 @@
 			group grpControls
 			type ITEM_TYPE_MULTI
 			text "Autopickup:"
-			cvar "ut_weapdrop"
+			cvar "cg_autopickup"
 			cvarFloatList { "No" 0 "Yes" -1 }
 			rect 0 165 320 15
 			textalign ITEM_ALIGN_RIGHT
@@ -525,6 +525,8 @@
 		itemDef {
 			name shoot
 			group grpControls
+			cvartest cg_autopickup
+			hidecvar { "-1" }
 			type ITEM_TYPE_BIND
 			text "interact/pickup:"
 			cvar "+button7"

--- a/menu/ui/ingame_controls.menu
+++ b/menu/ui/ingame_controls.menu
@@ -509,7 +509,7 @@
 			type ITEM_TYPE_MULTI
 			text "Autopickup:"
 			cvar "ut_weapdrop"
-			cvarFloatList { "No" 0 "Yes -1 }
+			cvarFloatList { "No" 0 "Yes" -1 }
 			rect 0 165 320 15
 			textalign ITEM_ALIGN_RIGHT
 			textalignx 187


### PR DESCRIPTION
- Added a toggle for cg_autopickup to the controls/shoot menu
- added an option to change the interact key (which is used for pickup) there. 
- Updated the "(def-)use" text in contros/misc to "interact/pickup" for consistency
