### PR TITLE
Hide the team select buttons in non team gamemodes

### DIFF
--- a/menu/ui/ingame_select_team.menu
+++ b/menu/ui/ingame_select_team.menu
@@ -614,7 +614,7 @@
 			visible 1
 			decoration
 			cvarTest "g_gametype"
-			disableCvar { "11" } 
+			disableCvar { "0" ; "1" ; "9" ; "11"}
 		}
 
 		itemDef {
@@ -655,7 +655,7 @@
 			visible 1
 			decoration
 			cvarTest "g_gametype"
-			disableCvar { "11" } 
+			disableCvar { "0" ; "1" ; "9" ; "11"}
 		}
 
 		itemDef {
@@ -731,7 +731,7 @@
 			visible 1
 			decoration
 			cvarTest "g_gametype"
-			disableCvar { "11" } 
+			disableCvar { "0" ; "1" ; "9" ; "11"}
 		}
 
 
@@ -752,7 +752,7 @@
 			visible 1
 			decoration
 			cvarTest "g_gametype"
-			disableCvar { "11" } 
+			disableCvar { "0" ; "1" ; "9" ; "11"} 
 		}
 
 


### PR DESCRIPTION
when in non teambased gamemodes, not only hide interactable box, but also the text, which for some reason was only hidden in gamemode 11?