### PR TITLE
Added support for instagib

### DIFF
--- a/menu/ui/ingame.txt
+++ b/menu/ui/ingame.txt
@@ -19,6 +19,7 @@
 	loadMenu { "ui/ingame_select_gear_item.menu" }
 	loadMenu { "ui/ingame_select_gear_grenade.menu" }
 	loadMenu { "ui/ingame_select_player.menu" }
-    loadMenu { "ui/ingame_select_player_readme.menu" }
+	loadMenu { "ui/ingame_select_player_readme.menu" }
 	loadMenu { "ui/ingame_ut_matchmode.menu" }
+	loadMenu { "ui/ingame_select_gear_instagib.menu" }
 }

--- a/menu/ui/ingame_player.menu
+++ b/menu/ui/ingame_player.menu
@@ -24,6 +24,24 @@
 			visible 1
 			decoration
 		}
+		
+		// INSTAGIB CATCHER
+		itemDef {
+			name gear
+			rect -2 -2 644 484
+			style WINDOW_STYLE_FILLED
+			type 1
+			forecolor 1 1 1 0
+			backcolor 0 0 0 0
+			border 0
+			bordercolor .5 .5 .5 1
+			visible 1
+			action { hide gear }
+			mouseEnter { hide gear }
+			cvarTest "g_instagib"
+			hideCvar { "0" }
+		}
+		
 
 		//  BUTTONS	//
 
@@ -43,7 +61,7 @@
 		}
 
 		itemDef {
-			name team
+			name gear
 			type 1
 			style 1
 			rect 10 56 128 20
@@ -60,7 +78,7 @@
 		}
 
 		itemDef {
-			name team
+			name player
 			type 1
 			style 1
 			rect 10 86 128 20
@@ -75,7 +93,7 @@
 		}
 
 		itemDef {
-			name team
+			name matchmode
 			type 1
 			style 1
 			rect 10 116 128 20
@@ -110,7 +128,7 @@
 		}
 
 		itemDef {
-			name team
+			name gear
 			text "weapon / gear select"
 			type 0
 			style 1
@@ -130,7 +148,7 @@
 		}
 
 		itemDef {
-			name team
+			name player
 			text "player setup"
 			type 0
 			style 1
@@ -148,7 +166,7 @@
 		}
 
 		itemDef {
-			name team
+			name matchmode
 			text "matchmode"
 			type 0
 			style 1

--- a/menu/ui/ingame_player.menu
+++ b/menu/ui/ingame_player.menu
@@ -36,8 +36,8 @@
 			border 0
 			bordercolor .5 .5 .5 1
 			visible 1
-			action { hide gear }
-			mouseEnter { hide gear }
+			action { hide gear; show gear_instagib }
+			OnFocus { hide gear; show gear_instagib }
 			cvarTest "g_instagib"
 			hideCvar { "0" }
 		}
@@ -76,6 +76,23 @@
 			cvarTest "g_gametype"
 			hideCvar { "11" }
 		}
+		
+		itemDef {
+			name gear_instagib
+			type 1
+			style 1
+			rect 10 56 128 20
+			forecolor  1 1 1 1
+			border 1
+			bordercolor .5 .5 .5 1
+			backcolor 0 0 0 .7
+			visible 0
+			ownerdrawParam	GEAR_ITEM_1
+			action { uiScript gearSetActive; open ingame_ut_select_gear_instagib ; close ingame ; close ingame_player ; play "sound/misc/kcaction.wav" }
+			mouseEnter { setcolor backcolor 0 0 .55 1 }
+			mouseExit { setcolor backcolor 0 0 0 .7}
+		}
+		
 
 		itemDef {
 			name player
@@ -146,6 +163,28 @@
 			cvarTest "g_gametype"
 			hideCvar { "11" }
 		}
+		
+		itemDef {
+			name gear_instagib
+			text "weapon / gear select"
+			type 0
+			style 1
+			rect 10 56 128 20
+			textalign 2
+			textalignx 124
+			textaligny 16
+			textscale .22
+			forecolor  1 1 1 1
+			border 1
+			bordercolor .5 .5 .5 1
+			backcolor 0 0 0 0
+			visible 0
+			cvarTest "g_instagib"
+			showCvar { "1" }
+			decoration
+		}
+
+		
 
 		itemDef {
 			name player

--- a/menu/ui/ingame_select_gear_instagib.menu
+++ b/menu/ui/ingame_select_gear_instagib.menu
@@ -1,0 +1,431 @@
+#include "ui/menudef.h"
+
+{
+	menuDef
+	{
+		name "ingame_ut_select_gear_instagib"
+		visible 0
+		fullscreen 0
+		rect -5 -5 650 490
+		focusColor 1 1 1 1
+		backcolor 0 0 0 0
+		style WINDOW_STYLE_FILLED
+		border 0
+		onEsc { close ingame_ut_select_gear_instagib ; open ingame_ut_select_team }
+		onOpen { uiScript gearRead }
+
+		itemdef {
+			name window
+			rect 73 79 494 321
+			style WINDOW_STYLE_SHADER
+			background "ui/assets/ingame_bg2_tr.tga"
+			border 1
+			bordercolor .5 .5 .5 1
+			visible 1
+			decoration
+		}
+
+		itemDef {
+			name window
+			rect 73 79 494 25
+			style WINDOW_STYLE_FILLED
+			forecolor 1 1 1 1
+			backcolor 0 0 0 .6
+			border 1
+			bordercolor .5 .5 .5 1
+			visible 1
+			decoration
+		}
+
+		//  TABS		//
+
+		itemdef {
+			name teamtab
+			type 1
+			rect 74 81 160 23
+			style WINDOW_STYLE_SHADER
+			background "ui/assets/tab_tr.tga"
+			//	border 1
+			//	bordercolor .5 .5 .5 1
+			visible 1
+			action { uiScript "gearSetItem" ; 
+			play "sound/misc/kcaction.wav" ;
+			uiScript gearWrite ;
+			close ingame_ut_select_gear_instagib ;
+			open ingame_ut_select_team }
+		}
+
+		itemdef {
+			name teamtab
+			rect 74 81 160 23
+			style 0
+			forecolor .5 .5 .5 1
+			text "team setup"
+			textscale .3
+			textalignx 10
+			textaligny 19
+			visible 1
+			decoration
+		}
+
+
+		itemdef {
+			name geartab
+			rect 224 81 160 23
+			style WINDOW_STYLE_SHADER
+			background "ui/assets/tab_on_tr.tga"
+			//	border 1
+			//	bordercolor .5 .5 .5 1
+			visible 1
+			decoration
+		}
+		
+
+		itemdef {
+			name geartab
+			rect 224 81 160 23
+			style 0
+			forecolor 1 1 1 1
+			text "weapons / items"
+			textscale .3
+			textalignx 10
+			textaligny 19
+			visible 1
+			decoration
+		}
+
+		itemDef {
+			name closeX
+			rect 544 83 20 17
+			style WINDOW_STYLE_FILLED
+			type 1
+			forecolor 1 1 1 1
+			backcolor 0 0 0 .6
+			border 1
+			bordercolor .5 .5 .5 1
+			visible 1
+			hotkey "0"
+			text "x"
+			textalign ITEM_ALIGN_CENTER
+			textscale 0.25
+			textalignx 9
+			textaligny 11
+			action { play "sound/misc/kcaction.wav" ; close ingame_ut_select_gear_instagib }
+			mouseEnter { setcolor backcolor 0 0 .55 1 }
+			mouseExit { setcolor backcolor 0 0 0 .7 }
+		} 
+
+//----------- 
+//HOVER ITEMS 
+//-----------
+
+
+		itemdef {
+			name PH6
+			group PHovers
+			type 1
+			style WINDOW_STYLE_FILLED
+			rect 77  107  140  118
+			hotkey 6
+			forecolor 1 1 1 1 
+			backcolor 0 0 0 .6
+			border 1 
+			bordercolor .5 .5 .5 .7
+			ownerdrawparam ITEM_NVG
+			text "6. Tactical Goggles" 
+			textscale 0.18
+			textalign 0
+			textalignx 2
+			textaligny 10
+			action { 
+				uiScript gearSetItem; 
+				uiScript gearWrite; 
+				uiScript gearEnd;
+				close ingame_ut_select_gear_instagib; 
+
+				play "sound/misc/kcaction.wav";  
+			}
+			mouseEnter { 
+				setcolor backcolor .5 .5 .5 .5
+				show nvg_info 
+			}
+			mouseExit { 
+				setcolor backcolor 0 0 0 .6
+				hide nvg_info 
+			}
+			onfocus { 
+				show nvg_info 
+			}
+			leavefocus { 
+				hide nvg_info 
+			}
+			visible 1
+		}
+		
+		
+
+
+		itemdef {
+			name PH9
+			group PHovers
+			type 1
+			style WINDOW_STYLE_FILLED
+			rect 217  107  140  118
+			hotkey 9
+			forecolor 1 1 1 1 
+			backcolor 0 0 0 .6
+			border 1 
+			bordercolor .5 .5 .5 .7
+			ownerdrawparam ITEM_LASER
+			text "9. No Tactical Goggles" 	
+			textscale 0.18
+			textalign 0
+			textalignx 2
+			textaligny 10
+			action { 
+				uiScript gearSetItem; 
+				uiScript gearWrite; 
+				uiScript gearEnd;
+				close ingame_ut_select_gear_instagib; 
+				
+				play "sound/misc/kcaction.wav"; 
+			}
+			mouseEnter { 
+				setcolor backcolor .5 .5 .5 .5
+				show none_info 
+			}
+			mouseExit { 
+				setcolor backcolor 0 0 0 .6
+				hide none_info 
+			}
+			onfocus { 
+				show none_info 
+			}
+			leavefocus { 
+				hide none_info 
+			}
+			visible 1
+		}
+		
+		itemdef {
+			name medkitstuff
+			group PHovers
+			type 1
+			style WINDOW_STYLE_FILLED
+			rect 77  226  280  118
+			hotkey 6
+			forecolor 1 1 1 1 
+			backcolor 0 0 0 .6
+			border 1 
+			bordercolor .5 .5 .5 .7
+			ownerdrawparam ITEM_NVG
+			text "Never Go out without your kit!" 
+			textscale .3
+			textalign 0
+			textalignx 15
+			textaligny 59
+			visible 1
+		}
+
+
+//----------- 
+//NORMAL ITEMS 
+//-----------
+		
+
+		itemdef {
+			name P5
+			group PNormal
+			rect 77  107  140  118
+			ownerdraw UI_ITEM_IMAGE
+			ownerdrawparam ITEM_NVG
+			visible 1 
+			decoration
+		}
+
+
+
+		itemdef {
+			name P9
+			group PNormal
+			rect 217  107  140  118
+			ownerdraw UI_ITEM_IMAGE
+			ownerdrawparam ITEM_NONE
+			visible 1 
+			decoration
+		}
+
+//----------- 
+//INFO IMAGES
+//-----------
+		
+
+		itemdef {
+			name nvg_info
+			group info
+			rect 366  107  140  118
+			ownerdraw UI_ITEM_IMAGE
+			ownerdrawparam ITEM_NVG
+			visible 0 
+			decoration
+		}
+
+
+		itemdef {
+			name none_info
+			group info
+			rect 366  107  192  118
+			ownerdraw UI_ITEM_IMAGE
+			ownerdrawparam ITEM_NONE
+			visible 0 
+			decoration
+		}
+		
+		itemdef { //item 2 is medkit. always.
+			name medkit_info
+			group info
+			rect 366  226  192  118
+			ownerdraw UI_ITEM_IMAGE
+			ownerdrawparam ITEM_MEDKIT
+			visible 1
+			decoration
+		}
+
+ 
+
+//----------- 
+//INFO WINDOW
+//-----------
+
+
+		itemdef {
+			name info_outline
+			group info
+			rect 366  107  192  118
+			style WINDOW_STYLE_FILLED
+			forecolor 1 1 1 1 
+			backcolor .2 .2 .3 .3 
+			border 1 
+			bordercolor .5 .5 .5 37 
+			textscale .24
+			textalign 0
+			textalignx 2
+			textaligny 115
+			wrapped
+			text "ITEM #1" 
+			visible 1 
+			decoration
+		}
+		
+		itemdef {
+			name info_outline
+			group info
+			rect 366  226  192  118
+			style WINDOW_STYLE_FILLED
+			forecolor 1 1 1 1 
+			backcolor .2 .2 .3 .3 
+			border 1 
+			bordercolor .5 .5 .5 37 
+			textscale .24
+			textalign 0
+			textalignx 2
+			textaligny 115
+			wrapped
+			text "ITEM #2" 
+			visible 1 
+			decoration
+		}
+
+ 
+
+//----------- 
+//INFO TEXT
+//-----------
+
+
+
+		itemdef {
+			name nvg_info
+			group info
+			rect 366  107  192  118
+			type 1
+			style WINDOW_STYLE_FILLED
+			forecolor 1 1 1 1 
+			backcolor .5 .5 .5 0 
+			border 0 
+			textscale 0.2
+			textalign 0
+			textalignx 5
+			textaligny 14
+			wrapped
+			text "Name:  Tactical Goggles\r" 
+			"Description:  Improves battlefield\rawareness\r" 
+			"Highlights players and grenades\r" 
+		}
+
+
+		itemdef {
+			name none_info
+			group info
+			rect 366  107  192  118
+			type 1
+			style WINDOW_STYLE_FILLED
+			forecolor 1 1 1 1 
+			backcolor .5 .5 .5 0 
+			border 0 
+			textscale 0.2
+			textalign 0
+			textalignx 5
+			textaligny 14
+			wrapped
+			text "Name:  No Item\r" 
+			"Has no value, except for not\r"
+			"having tactical goggles"
+		}
+		
+		
+		itemdef {
+			name medkit_info
+			group info
+			rect 366  226  192  118
+			type 1
+			style WINDOW_STYLE_FILLED
+			forecolor 1 1 1 1 
+			backcolor .5 .5 .5 0 
+			border 0 
+			textscale 0.2
+			textalign 0
+			textalignx 5
+			textaligny 14
+			wrapped
+			visible 1
+			text "Name:  Medkit\r" 
+			"Improves bandaging ability"
+		}
+ 
+
+//----------- 
+//CANCEL BUTTON 
+//-----------
+
+
+		itemDef { 
+			style WINDOW_STYLE_FILLED 
+			type 1 
+			rect 518 375 40 20 
+			forecolor 1 1 1 1 
+			backcolor 0 0 0 .6 
+			border 1 
+			bordercolor .5 .5 .5 .7 
+			text "Cancel" 
+			textalign ITEM_ALIGN_CENTER 
+			textalignx 20 
+			textaligny 13 
+			textscale 0.2 
+			visible 1 
+			action { close "ingame_ut_select_gear_instagib"; open "ingame_ut_select_gear" } 
+			mouseEnter { setcolor backcolor .5 .5 .5 .5 } 
+			mouseExit { setcolor backcolor 0 0 0 .6 } 
+		} 
+	} 
+}

--- a/menu/ui/ingame_select_team.menu
+++ b/menu/ui/ingame_select_team.menu
@@ -46,6 +46,25 @@
 		}
 
 		//  TABS		//
+		
+		
+		// INSTAGIB CATCHER
+		itemDef {
+			name geartab
+			rect -2 -2 644 484
+			style WINDOW_STYLE_FILLED
+			type 1
+			forecolor 1 1 1 0
+			backcolor 0 0 0 0
+			border 0
+			bordercolor .5 .5 .5 1
+			visible 1
+			action { hide geartab; show geartab_instagib }
+			mouseEnter { hide geartab; show geartab_instagib }
+			cvarTest "g_instagib"
+			hideCvar { "0" }
+		}
+
 
 		itemDef {
 			name geartab
@@ -63,24 +82,25 @@
 			cvarTest "g_gametype"
 			hideCvar { "11" }
 		}
-
-		// INSTAGIB CATCHER
+		
 		itemDef {
-			name geartab
-			rect -2 -2 644 484
-			style WINDOW_STYLE_FILLED
+			name geartab_instagib
 			type 1
-			forecolor 1 1 1 0
-			backcolor 0 0 0 0
-			border 0
-			bordercolor .5 .5 .5 1
-			visible 1
-			action { hide geartab }
-			mouseEnter { hide geartab }
+			rect 224 81 160 23
+			style WINDOW_STYLE_SHADER
+			background "ui/assets/tab_tr.tga"
+			forecolor .5 .5 .5 1
+			text "weapons / items"
+			textscale .3
+			textalignx 10
+			textaligny 19
+			visible 0
+			ownerdrawParam	GEAR_ITEM_1
+			action { play "sound/misc/kcaction.wav"; uiScript gearSetActive; close ingame_ut_select_team; open ingame_ut_select_gear_instagib }
 			cvarTest "g_instagib"
-			hideCvar { "0" }
+			showCvar { "1" }
 		}
-
+		
 		itemDef {
 			name teamtab
 			rect 74 81 160 23

--- a/menu/ui/ingame_select_team.menu
+++ b/menu/ui/ingame_select_team.menu
@@ -64,6 +64,22 @@
 			hideCvar { "11" }
 		}
 
+		// INSTAGIB CATCHER
+		itemDef {
+			name geartab
+			rect -2 -2 644 484
+			style WINDOW_STYLE_FILLED
+			type 1
+			forecolor 1 1 1 0
+			backcolor 0 0 0 0
+			border 0
+			bordercolor .5 .5 .5 1
+			visible 1
+			action { hide geartab }
+			mouseEnter { hide geartab }
+			cvarTest "g_instagib"
+			hideCvar { "0" }
+		}
 
 		itemDef {
 			name teamtab
@@ -509,8 +525,97 @@
 			visible 1
 			decoration
 		}
-
-
+		
+		// INSTAGIB INFO // 
+		
+		//box
+		itemDef {
+			name instagib
+			rect 446 114 111 116
+			type 1
+			style WINDOW_STYLE_FILLED
+			forecolor 1 1 1 1
+			backcolor 0 0 0 .6
+			border 1
+			bordercolor .6 .1 .1 1
+			bordersize 1
+			visible 1
+			mouseEnter { show instagibinfo}
+			mouseExit { hide instagibinfo }
+			cvarTest "g_instagib"
+			showCvar { "1" } 
+		}
+		
+		//text
+		itemDef {
+			textstyle 1 
+			name instagib
+			rect 446 114 111 116
+			type 0
+			wrapped
+			text "INSTAGIB\r"
+			textscale .30
+			textalign 0
+			textalignx 23
+			textaligny 63
+			style 1
+			forecolor 1 0 0 1
+			backcolor 0 0 0 0
+			border 0
+			bordersize 1
+			bordercolor 1 1 1 1
+			visible 1
+			decoration
+			cvarTest "g_instagib"
+			showCvar { "1" }
+		}
+		
+		//instagibinfo box
+		itemDef {
+			name instagibinfo
+			rect 83 114 343 276
+			type 0
+			style WINDOW_STYLE_FILLED
+			forecolor 1 1 1 1
+			backcolor 0 0 0 .99
+			border 1
+			bordercolor 1 1 1 1
+			bordersize 1
+			visible 0
+			mouseEnter { show instagibinfo}
+			mouseExit { hide instagibinfo }
+		}
+		
+		//instagibinfo text
+		itemDef	{
+			name instagibinfo
+			text "^1INSTAGIB"
+			textscale .33
+			forecolor 1 1 1 1
+			rect 94 144 100 30
+			visible 0
+			decoration
+		}
+		
+		itemDef	{
+			name instagibinfo
+			wrapped
+			text "Everyone is equipped with a deadly FS-Tod50. Every shot \r"
+			"kills. Every slice kills. The FS-Tod50 can penetrate targets\r"
+			"and ricochet off walls, if fired in a flat angle.\r\r"
+			"Every other aspect of the gamemode stays unchanged"
+			style 1
+			textscale .24
+			textalignx 0
+			textaligny 20
+			forecolor 1 1 1 1
+			backcolor 0 0 0 0
+			rect 93 154 323 226
+			visible 0
+			decoration
+		}
+		
+		
 		// TEAM BUTTONS 	//
 
 		itemDef {
@@ -594,7 +699,7 @@
 			mouseEnter { setcolor backcolor 0 0 .55 1 }
 			mouseExit { setcolor backcolor 0 0 0 .6 }
 			cvarTest "g_gametype"
-			disableCvar { "0" ; "1" ; "9" ; "11"} //@Barbatos 05/09/2012 added LMS //@Fenix 30/10/2012 added Jump Mode
+			hideCvar { "0" ; "1" ; "9" ; "11"} //@Barbatos 05/09/2012 added LMS //@Fenix 30/10/2012 added Jump Mode
 		}
 
 		itemDef {
@@ -614,7 +719,7 @@
 			visible 1
 			decoration
 			cvarTest "g_gametype"
-			disableCvar { "0" ; "1" ; "9" ; "11"}
+			hideCvar { "0" ; "1" ; "9" ; "11"}
 		}
 
 		itemDef {
@@ -635,7 +740,7 @@
 			mouseEnter { setcolor backcolor 0 0 .55 1 }
 			mouseExit { setcolor backcolor 0 0 0 .6 }
 			cvarTest "g_gametype"
-			disableCvar { "0" ; "1" ; "9" ; "11"} //@Barbatos 05/09/2012 added LMS	//@Fenix 30/10/2012 added Jump Mode
+			hideCvar { "0" ; "1" ; "9" ; "11"} //@Barbatos 05/09/2012 added LMS	//@Fenix 30/10/2012 added Jump Mode
 		}
 
 		itemDef {
@@ -655,7 +760,7 @@
 			visible 1
 			decoration
 			cvarTest "g_gametype"
-			disableCvar { "0" ; "1" ; "9" ; "11"}
+			hideCvar { "0" ; "1" ; "9" ; "11"}
 		}
 
 		itemDef {
@@ -731,7 +836,7 @@
 			visible 1
 			decoration
 			cvarTest "g_gametype"
-			disableCvar { "0" ; "1" ; "9" ; "11"}
+			hideCvar { "0" ; "1" ; "9" ; "11"}
 		}
 
 
@@ -752,7 +857,7 @@
 			visible 1
 			decoration
 			cvarTest "g_gametype"
-			disableCvar { "0" ; "1" ; "9" ; "11"} 
+			hideCvar { "0" ; "1" ; "9" ; "11"} 
 		}
 
 


### PR DESCRIPTION
Removed the "gear select" buttons from both the menu and the team select window via hacky "catchers" which will take the 1st mousemovement and remove the buttons and themselfs. Works as long as you stay on the map.

Also added more info about the instagib modifier to the team select window. Originally intended to add it below the gametype info, but couldnt as Bomb mode is too long.

A demo pk3 can be downloaded [here](http://www.mediafire.com/download/9ww2wdjl09iow6d/zzzINSTAGIB.pk3)

Preview:
![shot0003](https://cloud.githubusercontent.com/assets/8862732/18726125/4ceed386-8043-11e6-96b6-cc181f644574.jpg)
