### PR TITLE
Added r_noborder

### DIFF
--- a/menu/ui/ingame_system.menu
+++ b/menu/ui/ingame_system.menu
@@ -239,7 +239,7 @@
 			type ITEM_TYPE_YESNO
 			text "Fullscreen:"
 			cvar "r_fullscreen"
-			rect 30 120 259 20
+			rect 30 120 180 20
 			textalign ITEM_ALIGN_RIGHT
 			textalignx 140
 			textaligny 15
@@ -248,7 +248,24 @@
 			visible 0
 			action { play "sound/misc/kcaction.wav" }
 		}
-
+		
+		itemDef {
+			name graphics
+			group grpSystem
+			type ITEM_TYPE_YESNO
+			text "Noborder:"
+			cvar "r_noborder"
+			cvarTest "r_fullscreen"
+			showCvar { "0" }
+			rect 220 120 100 20
+			textalign ITEM_ALIGN_RIGHT
+			textalignx 40
+			textaligny 15
+			textscale .25
+			forecolor 1 1 1 1
+			visible 0
+			action { play "sound/misc/kcaction.wav" }
+		}
 
 		itemDef {
 			name graphics

--- a/menu/ui/system.menu
+++ b/menu/ui/system.menu
@@ -317,7 +317,7 @@
 				type ITEM_TYPE_YESNO
 				text "Fullscreen:"
 				cvar "r_fullscreen"
-				rect 150 100 200 20
+				rect 150 100 100 20
 				textalign ITEM_ALIGN_RIGHT
 				textalignx 40
 				textaligny 20
@@ -326,7 +326,24 @@
 				visible 0
 				action { play "sound/misc/kcaction.wav" }
 			}
-
+			
+			itemDef {
+				name graphics
+				group grpSystem
+				type ITEM_TYPE_YESNO
+				text "Noborder:"
+				cvar "r_noborder"
+				cvarTest "r_fullscreen"
+				showCvar { "0" }
+				rect 250 100 100 20
+				textalign ITEM_ALIGN_RIGHT
+				textalignx 40
+				textaligny 20
+				textscale .25
+				forecolor 1 1 1 1
+				visible 0
+				action { play "sound/misc/kcaction.wav" }
+			}
 
 			itemDef {
 				name graphics


### PR DESCRIPTION
Added r_noborder to systems.menu and ingame_system.menu

The menu was full, so i added it to the same line, and hid it when r_fullscreen is 1

I considered fancy catchers and something like a mergerd "Display mode" setup that would change both at the same time, but it was unreliable and create bad sound hints.
